### PR TITLE
Remove wildcard

### DIFF
--- a/github/workflows/tag-nexus-artifacts.yml
+++ b/github/workflows/tag-nexus-artifacts.yml
@@ -120,7 +120,6 @@ jobs:
           TAG_NAME_NPM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_NPM }}"
 
           VERSION_SUFFIX="${{ steps.parse.outputs.build_date }}-${{ steps.parse.outputs.run_id }}-${{ steps.parse.outputs.commit_sha }}"
-          ALL_ARTIFACTS_VERSION="*-${VERSION_SUFFIX}"
 
           cat >> $GITHUB_OUTPUT <<EOF
           TAG_NAME=$TAG_NAME
@@ -132,7 +131,7 @@ jobs:
           STAGING_REPO_DOCKER=${{ env.STAGING_REPO_DOCKER }}
           STAGING_REPO_HELM=${{ env.STAGING_REPO_HELM }}
           STAGING_REPO_NPM=${{ env.STAGING_REPO_NPM }}
-          ALL_ARTIFACTS_VERSION=$ALL_ARTIFACTS_VERSION
+          ALL_ARTIFACTS_VERSION=${{ inputs.version }}
           EOF
 
       - name: Summary


### PR DESCRIPTION
Searching for components do not work properly with wildcard patterns anymore. This is why the associate step in the build pipeline (tag-nexus-artifacts) failed.

https://help.sonatype.com/en/searching-for-components.html#keyword-search-query-string