### PR TITLE
fix(security): harden run-steps against script injection; fix release gating

### DIFF
--- a/.github/actions/add-helm-repositories/action.yml
+++ b/.github/actions/add-helm-repositories/action.yml
@@ -30,16 +30,21 @@ runs:
     - name: Add Helm repositories
       shell: bash
       if: ${{ inputs.repositories != '[]' }}
+      env:
+        HELM_USER: ${{ inputs.username }}
+        HELM_PASS: ${{ inputs.password }}
+        FORCE_UPDATE: ${{ inputs.force-update }}
+        REPOSITORIES: ${{ inputs.repositories }}
       run: |
-        echo '${{ inputs.repositories }}' | jq -c '.[]' | while IFS= read -r repo_json; do
+        echo "$REPOSITORIES" | jq -c '.[]' | while IFS= read -r repo_json; do
           repo_name=$(echo "$repo_json" | jq -r .name)
           repo_url=$(echo "$repo_json" | jq -r .url)
 
-          # Build the helm command with conditional --force-update flag
-          helm_cmd="helm repo add \"$repo_name\" \"$repo_url\" --username \"${{ inputs.username }}\" --password \"${{ inputs.password }}\""
-          if [[ "${{ inputs.force-update }}" == "true" ]]; then
-            helm_cmd="$helm_cmd --force-update"
+          # Build the helm arguments with conditional --force-update flag
+          helm_args=(repo add "$repo_name" "$repo_url" --username "$HELM_USER" --password "$HELM_PASS")
+          if [[ "$FORCE_UPDATE" == "true" ]]; then
+            helm_args+=(--force-update)
           fi
 
-          eval "$helm_cmd"
+          helm "${helm_args[@]}"
         done

--- a/.github/actions/base/add-helm-repositories/action.yml
+++ b/.github/actions/base/add-helm-repositories/action.yml
@@ -30,16 +30,21 @@ runs:
     - name: Add Helm repositories
       shell: bash
       if: ${{ inputs.repositories != '[]' }}
+      env:
+        HELM_USER: ${{ inputs.username }}
+        HELM_PASS: ${{ inputs.password }}
+        FORCE_UPDATE: ${{ inputs.force-update }}
+        REPOSITORIES: ${{ inputs.repositories }}
       run: |
-        echo '${{ inputs.repositories }}' | jq -c '.[]' | while IFS= read -r repo_json; do
+        echo "$REPOSITORIES" | jq -c '.[]' | while IFS= read -r repo_json; do
           repo_name=$(echo "$repo_json" | jq -r .name)
           repo_url=$(echo "$repo_json" | jq -r .url)
 
-          # Build the helm command with conditional --force-update flag
-          helm_cmd="helm repo add \"$repo_name\" \"$repo_url\" --username \"${{ inputs.username }}\" --password \"${{ inputs.password }}\""
-          if [[ "${{ inputs.force-update }}" == "true" ]]; then
-            helm_cmd="$helm_cmd --force-update"
+          # Build the helm arguments with conditional --force-update flag
+          helm_args=(repo add "$repo_name" "$repo_url" --username "$HELM_USER" --password "$HELM_PASS")
+          if [[ "$FORCE_UPDATE" == "true" ]]; then
+            helm_args+=(--force-update)
           fi
 
-          eval "$helm_cmd"
+          helm "${helm_args[@]}"
         done

--- a/.github/actions/base/check-write-permission/action.yml
+++ b/.github/actions/base/check-write-permission/action.yml
@@ -12,17 +12,22 @@ runs:
     - name: Check checks:write permission
       id: check
       shell: bash
+      env:
+        REPOSITORY: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        echo "::debug::Checking checks:write permission for repo: ${{ github.repository }}"
-        echo "::debug::Event name: ${{ github.event_name }}"
-        echo "::debug::Actor: ${{ github.actor }}"
+        echo "::debug::Checking checks:write permission for repo: $REPOSITORY"
+        echo "::debug::Event name: $EVENT_NAME"
+        echo "::debug::Actor: $ACTOR"
 
         # Test if we have checks:write permission by attempting to create a check run.
         # 422 = permission granted (invalid request body), 403 = no permission
         RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-          -H "Authorization: Bearer ${{ github.token }}" \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github+json" \
-          "https://api.github.com/repos/${{ github.repository }}/check-runs" \
+          "https://api.github.com/repos/$REPOSITORY/check-runs" \
           -d '{}')
 
         HTTP_CODE=$(echo "$RESPONSE" | tail -n1)

--- a/.github/actions/base/parse-version/action.yml
+++ b/.github/actions/base/parse-version/action.yml
@@ -35,10 +35,12 @@ runs:
     - name: Parse version
       id: version
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
       run: |
-        IFS=- read SEM_VER BUILD_DATE RUN_ID COMMIT_SHA <<< "${{ inputs.version }}"
+        IFS=- read SEM_VER BUILD_DATE RUN_ID COMMIT_SHA <<< "$VERSION"
 
-        cat >> $GITHUB_OUTPUT <<EOF  
+        cat >> $GITHUB_OUTPUT <<EOF
         SEM_VER=$SEM_VER
         BUILD_DATE=$BUILD_DATE
         RUN_ID=$RUN_ID
@@ -48,8 +50,10 @@ runs:
     - name: Parse SemVer
       id: semver
       shell: bash
+      env:
+        SEM_VER: ${{ steps.version.outputs.SEM_VER }}
       run: |
-        IFS=. read MAJOR MINOR PATCH <<< "${{ steps.version.outputs.SEM_VER }}"
+        IFS=. read MAJOR MINOR PATCH <<< "$SEM_VER"
 
         cat >> $GITHUB_OUTPUT <<EOF  
         MAJOR=$MAJOR

--- a/.github/actions/base/publish-checkstyle-report/action.yml
+++ b/.github/actions/base/publish-checkstyle-report/action.yml
@@ -15,8 +15,10 @@ runs:
   steps:
     - name: Run Checkstyle
       shell: bash
+      env:
+        SETTINGS_FILE: ${{ inputs.settings_file }}
       run: |
-        mvn -B -V --no-transfer-progress --settings ${{ inputs.settings_file }} initialize checkstyle:check
+        mvn -B -V --no-transfer-progress --settings "$SETTINGS_FILE" initialize checkstyle:check
 
     - name: Check for Checkstyle results
       id: checkstyle_results

--- a/.github/actions/base/publish-spotbugs-report/action.yml
+++ b/.github/actions/base/publish-spotbugs-report/action.yml
@@ -15,8 +15,10 @@ runs:
   steps:
     - name: Run SpotBugs
       shell: bash
+      env:
+        SETTINGS_FILE: ${{ inputs.settings_file }}
       run: |
-        mvn -B -V --no-transfer-progress --settings ${{ inputs.settings_file }} initialize spotbugs:check
+        mvn -B -V --no-transfer-progress --settings "$SETTINGS_FILE" initialize spotbugs:check
 
     - name: Check for SpotBugs results
       id: spotbugs_results

--- a/.github/actions/base/set-maven-project-version/action.yml
+++ b/.github/actions/base/set-maven-project-version/action.yml
@@ -18,8 +18,11 @@ runs:
     - name: Set version (script)
       shell: bash
       if: ${{ inputs.script == 'true' }}
+      env:
+        VERSION: ${{ inputs.version }}
+        SETTINGS_FILE_INPUT: ${{ inputs.settings-file }}
       run: |
-        SETTINGS_FILE=$(echo "${{ inputs.settings-file }}" | tr -d '[:space:]')
+        SETTINGS_FILE=$(echo "$SETTINGS_FILE_INPUT" | tr -d '[:space:]')
 
         if [[ -n "$SETTINGS_FILE" && ! -f "$SETTINGS_FILE" ]]; then
           echo "Error: Settings file '$SETTINGS_FILE' does not exist."
@@ -27,16 +30,19 @@ runs:
         fi
 
         if [[ -n "$SETTINGS_FILE" ]]; then
-          MAVEN_SETTINGS_PATH="$SETTINGS_FILE" ${GITHUB_ACTION_PATH}/set-mvn-version.sh ${{ inputs.version }}
+          MAVEN_SETTINGS_PATH="$SETTINGS_FILE" ${GITHUB_ACTION_PATH}/set-mvn-version.sh "$VERSION"
         else
-          ${GITHUB_ACTION_PATH}/set-mvn-version.sh ${{ inputs.version }}
+          ${GITHUB_ACTION_PATH}/set-mvn-version.sh "$VERSION"
         fi
 
     - name: Set version (mvn plugin, custom settings)
       shell: bash
       if: ${{ inputs.script != 'true' }}
+      env:
+        VERSION: ${{ inputs.version }}
+        SETTINGS_FILE_INPUT: ${{ inputs.settings-file }}
       run: |
-        SETTINGS_FILE=$(echo "${{ inputs.settings-file }}" | tr -d '[:space:]')
+        SETTINGS_FILE=$(echo "$SETTINGS_FILE_INPUT" | tr -d '[:space:]')
 
         if [[ -n "$SETTINGS_FILE" && ! -f "$SETTINGS_FILE" ]]; then
           echo "Error: Settings file '$SETTINGS_FILE' does not exist."
@@ -44,7 +50,7 @@ runs:
         fi
 
         if [[ -n "$SETTINGS_FILE" ]]; then
-          mvn -B -V --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false --settings "$SETTINGS_FILE"
+          mvn -B -V --no-transfer-progress versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false --settings "$SETTINGS_FILE"
         else
-          mvn -B -V --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false
+          mvn -B -V --no-transfer-progress versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
         fi

--- a/.github/actions/base/setup-npm-nexus-access/action.yml
+++ b/.github/actions/base/setup-npm-nexus-access/action.yml
@@ -21,11 +21,11 @@ runs:
     - name: Add Nexus NPM credentials
       shell: bash
       run: |
-        cat << EOF >> '${{ inputs.auth-file }}'
+        cat << EOF >> "$AUTH_FILE"
         //$NEXUS_URL/repository/$NPM_REPOSITORY/:_authToken=$NPM_TOKEN
         EOF
-        cat '${{ inputs.auth-file }}'
       env:
         NPM_TOKEN: ${{ inputs.token }}
         NPM_REPOSITORY: ${{ inputs.repository }}
         NEXUS_URL: ${{ inputs.nexus-url }}
+        AUTH_FILE: ${{ inputs.auth-file }}

--- a/.github/actions/copy-docker-images/action.yml
+++ b/.github/actions/copy-docker-images/action.yml
@@ -20,9 +20,14 @@ runs:
   steps:
     - name: Copy multi-arch docker image
       shell: bash
+      env:
+        SOURCE_CREDENTIALS: ${{ inputs.source_credentials }}
+        DESTINATION_CREDENTIALS: ${{ inputs.destination_credentials }}
+        SOURCE_IMAGE: ${{ inputs.source_image }}
+        DESTINATION_IMAGE: ${{ inputs.destination_image }}
       run: |
         docker run --rm quay.io/skopeo/stable:v1 copy \
           --all \
-          --src-creds ${{ inputs.source_credentials }} \
-          --dest-creds ${{ inputs.destination_credentials }} \
-          docker://${{ inputs.source_image }} docker://${{ inputs.destination_image }}
+          --src-creds "$SOURCE_CREDENTIALS" \
+          --dest-creds "$DESTINATION_CREDENTIALS" \
+          "docker://$SOURCE_IMAGE" "docker://$DESTINATION_IMAGE"

--- a/.github/actions/ensure-branch/action.yml
+++ b/.github/actions/ensure-branch/action.yml
@@ -17,23 +17,29 @@ runs:
 
     - name: Check if branch exists
       id: branch_check
+      env:
+        BRANCH: ${{ inputs.branch }}
       run: |
-        if [[ -n $(git ls-remote --heads origin ${{ inputs.branch }}) ]]; then
+        if [[ -n $(git ls-remote --heads origin "$BRANCH") ]]; then
             echo "exists=true" >> $GITHUB_OUTPUT
         else
-            echo "exists=false" >> $GITHUB_OUTPUT          
+            echo "exists=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
 
     - name: Branch exists
       if: steps.branch_check.outputs.exists == 'true'
       shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
       run: |
-        echo "Branch '${{ inputs.branch }}' exists!"
+        echo "Branch '$BRANCH' exists!"
 
     - name: Branch does NOT exists
       if: steps.branch_check.outputs.exists == 'false'
       shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
       run: |
-        echo "Branch '${{ inputs.branch }}' does NOT exist. Aborting..."
+        echo "Branch '$BRANCH' does NOT exist. Aborting..."
         exit 1

--- a/.github/actions/install-mvnd/action.yaml
+++ b/.github/actions/install-mvnd/action.yaml
@@ -39,10 +39,16 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - run: curl -fsSL -o mvnd.zip https://downloads.apache.org/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip
+    - env:
+        VERSION: ${{ inputs.version }}
+        DISTRIBUTION: ${{ inputs.distribution }}
+      run: curl -fsSL -o mvnd.zip "https://downloads.apache.org/maven/mvnd/$VERSION/maven-mvnd-$VERSION-$DISTRIBUTION.zip"
       if: inputs.dry-run == 'false'
       shell: bash
-    - run: curl -fsSL -o mvnd.zip.sha256 https://downloads.apache.org/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}.zip.sha256
+    - env:
+        VERSION: ${{ inputs.version }}
+        DISTRIBUTION: ${{ inputs.distribution }}
+      run: curl -fsSL -o mvnd.zip.sha256 "https://downloads.apache.org/maven/mvnd/$VERSION/maven-mvnd-$VERSION-$DISTRIBUTION.zip.sha256"
       if: inputs.dry-run == 'false'
       shell: bash
     - id: integrity-check
@@ -53,7 +59,10 @@ runs:
       if: inputs.dry-run == 'false'
       shell: bash
     - id: mvnd-location
-      run: echo "mvnd-dir=/tmp/maven-mvnd-${{ inputs.version }}-${{ inputs.distribution }}/bin" >> $GITHUB_OUTPUT
+      env:
+        VERSION: ${{ inputs.version }}
+        DISTRIBUTION: ${{ inputs.distribution }}
+      run: echo "mvnd-dir=/tmp/maven-mvnd-$VERSION-$DISTRIBUTION/bin" >> $GITHUB_OUTPUT
       shell: bash
 #    - id: mvnd-opts
 #      run: echo "MVND_OPTS=-P apache-snapshots -V -e -ntp -Dmvnd.threads=2 -Daether.connector.http.connectionMaxTtl=120 -Daether.connector.requestTimeout=300000 -Daether.dependencyCollector.impl=bf -Dmaven.artifact.threads=25 -Dci.env.name=github.com -Dsurefire.rerunFailingTestsCount=2 -Dfailsafe.rerunFailingTestsCount=2" >> $GITHUB_ENV

--- a/.github/actions/parse-version/action.yml
+++ b/.github/actions/parse-version/action.yml
@@ -35,10 +35,12 @@ runs:
     - name: Parse version
       id: version
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
       run: |
-        IFS=- read SEM_VER BUILD_DATE RUN_ID COMMIT_SHA <<< "${{ inputs.version }}"
+        IFS=- read SEM_VER BUILD_DATE RUN_ID COMMIT_SHA <<< "$VERSION"
 
-        cat >> $GITHUB_OUTPUT <<EOF  
+        cat >> $GITHUB_OUTPUT <<EOF
         SEM_VER=$SEM_VER
         BUILD_DATE=$BUILD_DATE
         RUN_ID=$RUN_ID
@@ -48,8 +50,10 @@ runs:
     - name: Parse SemVer
       id: semver
       shell: bash
+      env:
+        SEM_VER: ${{ steps.version.outputs.SEM_VER }}
       run: |
-        IFS=. read MAJOR MINOR PATCH <<< "${{ steps.version.outputs.SEM_VER }}"
+        IFS=. read MAJOR MINOR PATCH <<< "$SEM_VER"
 
         cat >> $GITHUB_OUTPUT <<EOF  
         MAJOR=$MAJOR

--- a/.github/actions/release-docker-images/action.yml
+++ b/.github/actions/release-docker-images/action.yml
@@ -27,12 +27,19 @@ runs:
     # https://help.sonatype.com/en/staging.html
     - name: Move docker images
       shell: bash
+      env:
+        NEXUS3_URL: ${{ inputs.nexus3_url }}
+        NEXUS_USER: ${{ inputs.nexus3_user }}
+        NEXUS_PW: ${{ inputs.nexus3_password }}
+        DOCKER_STAGING_REGISTRY: ${{ inputs.source_registry }}
+        DOCKER_RELEASE_REGISTRY: ${{ inputs.target_registry }}
+        TAG: ${{ inputs.tag }}
       run: |
         docker run --rm -t \
-          -v ${{ github.action_path }}:/tmp \
-          -e NEXUS3_URL="${{ inputs.nexus3_url }}" \
-          -e NEXUS_USER="${{ inputs.nexus3_user }}" \
-          -e NEXUS_PW="${{ inputs.nexus3_password }}" \
-          -e DOCKER_STAGING_REGISTRY="${{ inputs.source_registry }}" \
-          -e DOCKER_RELEASE_REGISTRY="${{ inputs.target_registry }}" \
-          peschee/zx:2.0.0 /tmp/release-nexus-tag.mjs "${{ inputs.tag }}" --quiet
+          -v "$GITHUB_ACTION_PATH:/tmp" \
+          -e NEXUS3_URL="$NEXUS3_URL" \
+          -e NEXUS_USER="$NEXUS_USER" \
+          -e NEXUS_PW="$NEXUS_PW" \
+          -e DOCKER_STAGING_REGISTRY="$DOCKER_STAGING_REGISTRY" \
+          -e DOCKER_RELEASE_REGISTRY="$DOCKER_RELEASE_REGISTRY" \
+          peschee/zx:2.0.0 /tmp/release-nexus-tag.mjs "$TAG" --quiet

--- a/.github/actions/release-jira/action.yml
+++ b/.github/actions/release-jira/action.yml
@@ -21,6 +21,9 @@ runs:
     - name: Update Changelog
       env:
         JIRA_BASIC_AUTH_TOKEN: '${{ inputs.jira_basic_auth_token }}'
+        COMPONENT_NAME: ${{ inputs.component_name }}
+        SEMVER: ${{ inputs.semver }}
+        VERSION: ${{ inputs.version }}
       shell: bash
       run: |
-        ${{ github.action_path }}/jiraRelease.sh "${{ inputs.component_name }}" "${{ inputs.semver }}" "${{ inputs.version }}"
+        "$GITHUB_ACTION_PATH/jiraRelease.sh" "$COMPONENT_NAME" "$SEMVER" "$VERSION"

--- a/.github/actions/send-rocket-chat-message/action.yml
+++ b/.github/actions/send-rocket-chat-message/action.yml
@@ -17,5 +17,9 @@ runs:
     # No need to install Node as it is available on all GitHub runners…
     - name: Send Rocket.Chat message
       shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        CHANNEL: ${{ inputs.channel }}
+        MESSAGE: ${{ inputs.message }}
       run: |
-        node ${{ github.action_path }}/send-rocketchat-message.mjs ${{ inputs.webhook_url }} ${{ inputs.channel }} "${{ inputs.message }}"
+        node "$GITHUB_ACTION_PATH/send-rocketchat-message.mjs" "$WEBHOOK_URL" "$CHANNEL" "$MESSAGE"

--- a/.github/actions/set-maven-project-version/action.yml
+++ b/.github/actions/set-maven-project-version/action.yml
@@ -18,8 +18,11 @@ runs:
     - name: Set version (script)
       shell: bash
       if: ${{ inputs.script == 'true' }}
+      env:
+        VERSION: ${{ inputs.version }}
+        SETTINGS_FILE_INPUT: ${{ inputs.settings-file }}
       run: |
-        SETTINGS_FILE=$(echo "${{ inputs.settings-file }}" | tr -d '[:space:]')
+        SETTINGS_FILE=$(echo "$SETTINGS_FILE_INPUT" | tr -d '[:space:]')
 
         if [[ -n "$SETTINGS_FILE" && ! -f "$SETTINGS_FILE" ]]; then
           echo "Error: Settings file '$SETTINGS_FILE' does not exist."
@@ -27,16 +30,19 @@ runs:
         fi
 
         if [[ -n "$SETTINGS_FILE" ]]; then
-          MAVEN_SETTINGS_PATH="$SETTINGS_FILE" ${GITHUB_ACTION_PATH}/set-mvn-version.sh ${{ inputs.version }}
+          MAVEN_SETTINGS_PATH="$SETTINGS_FILE" ${GITHUB_ACTION_PATH}/set-mvn-version.sh "$VERSION"
         else
-          ${GITHUB_ACTION_PATH}/set-mvn-version.sh ${{ inputs.version }}
+          ${GITHUB_ACTION_PATH}/set-mvn-version.sh "$VERSION"
         fi
 
     - name: Set version (mvn plugin, custom settings)
       shell: bash
       if: ${{ inputs.script != 'true' }}
+      env:
+        VERSION: ${{ inputs.version }}
+        SETTINGS_FILE_INPUT: ${{ inputs.settings-file }}
       run: |
-        SETTINGS_FILE=$(echo "${{ inputs.settings-file }}" | tr -d '[:space:]')
+        SETTINGS_FILE=$(echo "$SETTINGS_FILE_INPUT" | tr -d '[:space:]')
 
         if [[ -n "$SETTINGS_FILE" && ! -f "$SETTINGS_FILE" ]]; then
           echo "Error: Settings file '$SETTINGS_FILE' does not exist."
@@ -44,7 +50,7 @@ runs:
         fi
 
         if [[ -n "$SETTINGS_FILE" ]]; then
-          mvn -B -V --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false --settings "$SETTINGS_FILE"
+          mvn -B -V --no-transfer-progress versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false --settings "$SETTINGS_FILE"
         else
-          mvn -B -V --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }} -DgenerateBackupPoms=false
+          mvn -B -V --no-transfer-progress versions:set -DnewVersion="$VERSION" -DgenerateBackupPoms=false
         fi

--- a/.github/actions/setup-npm-nexus-access/action.yml
+++ b/.github/actions/setup-npm-nexus-access/action.yml
@@ -21,11 +21,11 @@ runs:
     - name: Add Nexus NPM credentials
       shell: bash
       run: |
-        cat << EOF >> '${{ inputs.auth-file }}'
+        cat << EOF >> "$AUTH_FILE"
         //$NEXUS_URL/repository/$NPM_REPOSITORY/:_authToken=$NPM_TOKEN
         EOF
-        cat '${{ inputs.auth-file }}'
       env:
         NPM_TOKEN: ${{ inputs.token }}
         NPM_REPOSITORY: ${{ inputs.repository }}
         NEXUS_URL: ${{ inputs.nexus-url }}
+        AUTH_FILE: ${{ inputs.auth-file }}

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -45,9 +45,11 @@ jobs:
           ref: ${{ inputs.branch_name }}
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Update Changelog
         uses: uniport/workflows/.github/actions/update-changelog@main
@@ -62,5 +64,7 @@ jobs:
               --message "Update changelog with new version and prepare next unreleased version"
 
       - name: Push tag
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
         run: |
-          git push origin ${{ inputs.branch_name }}
+          git push origin "$BRANCH_NAME"

--- a/.github/workflows/copy-docker-image.yml
+++ b/.github/workflows/copy-docker-image.yml
@@ -46,10 +46,16 @@ jobs:
 
       - name: Summary
         shell: bash
+        env:
+          SOURCE_REGISTRY: ${{ inputs.source_registry }}
+          SOURCE_IMAGE: ${{ inputs.source_image }}
+          DESTINATION_REGISTRY: ${{ inputs.destination_registry }}
+          DESTINATION_IMAGE: ${{ inputs.destination_image }}
+          VERSION: ${{ inputs.version }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ## Setup
           ### Outputs
-          - **SOURCE_IMAGE**: \`${{ inputs.source_registry }}/${{ inputs.source_image }}:${{ inputs.version }}\`
-          - **DESTINATION_IMAGE**: \`${{ inputs.destination_registry }}/${{ inputs.destination_image }}:${{ inputs.version }}\`
+          - **SOURCE_IMAGE**: \`$SOURCE_REGISTRY/$SOURCE_IMAGE:$VERSION\`
+          - **DESTINATION_IMAGE**: \`$DESTINATION_REGISTRY/$DESTINATION_IMAGE:$VERSION\`
           EOF

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -76,19 +76,28 @@ jobs:
           path: deployment-repo
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           cd deployment-repo
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Configure deployment
+        env:
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           cd deployment-repo
-          ./updateVersion.sh "${{ inputs.component_name }}" "${{ inputs.version }}"
-          git push origin ${{ inputs.branch }}
+          ./updateVersion.sh "$COMPONENT_NAME" "$VERSION"
+          git push origin "$BRANCH"
 
       - name: Build summary
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           echo "## Deploy DEV Details" >> $GITHUB_STEP_SUMMARY
-          echo "- **version**: \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **branch**: \`${{ inputs.branch }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **version**: \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **branch**: \`$BRANCH\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/git-patch-branch-create.yml
+++ b/.github/workflows/git-patch-branch-create.yml
@@ -49,8 +49,11 @@ jobs:
       - name: Setup
         id: setup
         shell: bash
+        env:
+          MAJOR: ${{ inputs.major }}
+          MINOR: ${{ inputs.minor }}
         run: |
-          PATCH_BRANCH_NAME="${{ inputs.major }}.${{ inputs.minor }}.x"
+          PATCH_BRANCH_NAME="$MAJOR.$MINOR.x"
 
           cat >> $GITHUB_OUTPUT <<EOF
           PATCH_BRANCH_NAME=$PATCH_BRANCH_NAME
@@ -63,29 +66,40 @@ jobs:
           ref: ${{ inputs.branch_name }}
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Switch to/Create patch branch
+        env:
+          PATCH_BRANCH_NAME: ${{ steps.setup.outputs.PATCH_BRANCH_NAME }}
         run: |
-          git switch "${{ steps.setup.outputs.PATCH_BRANCH_NAME }}" || git switch --create "${{ steps.setup.outputs.PATCH_BRANCH_NAME }}"
+          git switch "$PATCH_BRANCH_NAME" || git switch --create "$PATCH_BRANCH_NAME"
 
       - name: Push patch branch
         if: ${{ inputs.patch != '0' }}
         shell: bash
+        env:
+          PATCH_BRANCH_NAME: ${{ steps.setup.outputs.PATCH_BRANCH_NAME }}
         run: |
-          git push origin "${{ steps.setup.outputs.PATCH_BRANCH_NAME }}"
+          git push origin "$PATCH_BRANCH_NAME"
 
       - name: Summary
         shell: bash
+        env:
+          MAJOR: ${{ inputs.major }}
+          MINOR: ${{ inputs.minor }}
+          PATCH: ${{ inputs.patch }}
+          PATCH_BRANCH_NAME: ${{ steps.setup.outputs.PATCH_BRANCH_NAME }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF  
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup
           ### Inputs
-          - **major**: \`${{ inputs.major }}\`          
-          - **minor**: \`${{ inputs.minor }}\`          
-          - **patch**: \`${{ inputs.patch }}\`          
+          - **major**: \`$MAJOR\`
+          - **minor**: \`$MINOR\`
+          - **patch**: \`$PATCH\`
           ### Outputs
-          - **PATCH_BRANCH_NAME**: \`${{ steps.setup.outputs.PATCH_BRANCH_NAME }}\`
+          - **PATCH_BRANCH_NAME**: \`$PATCH_BRANCH_NAME\`
           EOF

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -47,23 +47,31 @@ jobs:
           fetch-tags: true
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Create Git Tag
         shell: bash
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          TAG_MESSAGE: ${{ inputs.tag_message }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
           echo "Running on branch: $(git rev-parse --abbrev-ref HEAD)"
 
           git tag \
-            --annotate "${{ inputs.tag_name }}" \
-            --message "${{ inputs.tag_message }}" \
-            "${{inputs.commit_sha }}"
+            --annotate "$TAG_NAME" \
+            --message "$TAG_MESSAGE" \
+            "$COMMIT_SHA"
 
       # There's an issue in GitHub where changes cannot be pushed from an action if the tag points to a commit where
       # the contents of .github/workflows/ are not identical to the contents of .github/workflows/ on the latest commit of any branch!
       # @see https://github.com/orgs/community/discussions/151442
       - name: Push tag
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          git push origin ${{ inputs.tag_name }}
+          git push origin "$TAG_NAME"

--- a/.github/workflows/jira-release.yml
+++ b/.github/workflows/jira-release.yml
@@ -47,8 +47,11 @@ jobs:
       - name: Setup
         id: setup
         shell: bash
+        env:
+          ATLASSIAN_AUTH_USR: ${{ vars.ATLASSIAN_AUTH_USR }}
+          ATLASSIAN_AUTH_TOKEN: ${{ secrets.ATLASSIAN_AUTH_TOKEN }}
         run: |
-          JIRA_BASIC_AUTH_TOKEN=$(echo -n "${{ vars.ATLASSIAN_AUTH_USR }}:${{ secrets.ATLASSIAN_AUTH_TOKEN }}" | base64 -w0 -)
+          JIRA_BASIC_AUTH_TOKEN=$(echo -n "$ATLASSIAN_AUTH_USR:$ATLASSIAN_AUTH_TOKEN" | base64 -w0 -)
 
           echo "JIRA_BASIC_AUTH_TOKEN=$JIRA_BASIC_AUTH_TOKEN" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/main-maven-build.yml
+++ b/.github/workflows/main-maven-build.yml
@@ -88,8 +88,10 @@ jobs:
 
       - name: Unlock keychain (macOS runners)
         if: ${{ contains(runner.name, 'macduff') }}
+        env:
+          MACDUFF_KEYCHAIN_PASSWORD: ${{ secrets.MACDUFF_KEYCHAIN_PASSWORD }}
         run: |
-          security unlock-keychain -p "${{ secrets.MACDUFF_KEYCHAIN_PASSWORD }}"
+          security unlock-keychain -p "$MACDUFF_KEYCHAIN_PASSWORD"
 
       - name: Setup Helm repositories
         uses: uniport/workflows/.github/actions/base/add-helm-repositories@main
@@ -164,11 +166,14 @@ jobs:
           lcov: frontend/src/main/web/coverage/lcov.info
 
       - name: Build summary
+        env:
+          RC_VERSION: ${{ steps.vars.outputs.RC_VERSION }}
+          GROUP_ID: ${{ steps.vars.outputs.GROUP_ID }}
         run: |
           cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Maven Build
           This workflow ran successfully on **$(date)**.
           ### Outputs
-          - **VERSION**: \`${{ steps.vars.outputs.RC_VERSION }}\`
-          - **GROUP_ID**: \`${{ steps.vars.outputs.GROUP_ID }}\`
+          - **VERSION**: \`${RC_VERSION}\`
+          - **GROUP_ID**: \`${GROUP_ID}\`
           EOF

--- a/.github/workflows/move-nexus-artifacts.yml
+++ b/.github/workflows/move-nexus-artifacts.yml
@@ -73,11 +73,13 @@ jobs:
           TAG_NAME_SUFFIX_DOCKER_HELM: ${{ vars.TAG_NAME_SUFFIX_DOCKER }}
           TAG_NAME_SUFFIX_MAVEN: ${{ vars.TAG_NAME_SUFFIX_MAVEN }}
           TAG_NAME_SUFFIX_NPM: ${{ vars.TAG_NAME_SUFFIX_NPM }}
+          GROUP_ID: ${{ steps.properties.outputs.GROUP_ID }}
+          VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -u
 
-          TAG_NAME="${{ steps.properties.outputs.GROUP_ID }}_${{ inputs.version }}"
+          TAG_NAME="${GROUP_ID}_${VERSION}"
 
           TAG_NAME_DOCKER_HELM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_DOCKER_HELM }}"
           TAG_NAME_MAVEN="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_MAVEN }}"
@@ -91,18 +93,26 @@ jobs:
 
       - name: Summary
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          MOVE_MAVEN: ${{ inputs.move_maven }}
+          MOVE_DOCKER_HELM: ${{ inputs.move_docker_helm }}
+          MOVE_NPM: ${{ inputs.move_npm }}
+          TAG_NAME_DOCKER_HELM: ${{ steps.variables.outputs.TAG_NAME_DOCKER_HELM }}
+          TAG_NAME_MAVEN: ${{ steps.variables.outputs.TAG_NAME_MAVEN }}
+          TAG_NAME_NPM: ${{ steps.variables.outputs.TAG_NAME_NPM }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF  
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup
           ### Inputs
-          - **version**: \`${{ inputs.version }}\`
-          - **move_maven**: \`${{ inputs.move_maven }}\`
-          - **move_docker_helm**: \`${{ inputs.move_docker_helm }}\`
-          - **move_npm**: \`${{ inputs.move_npm }}\`
+          - **version**: \`${VERSION}\`
+          - **move_maven**: \`${MOVE_MAVEN}\`
+          - **move_docker_helm**: \`${MOVE_DOCKER_HELM}\`
+          - **move_npm**: \`${MOVE_NPM}\`
           ### Outputs
-          - **TAG_NAME_DOCKER_HELM**: \`${{ steps.variables.outputs.TAG_NAME_DOCKER_HELM }}\`
-          - **TAG_NAME_MAVEN**: \`${{ steps.variables.outputs.TAG_NAME_MAVEN }}\`
-          - **TAG_NAME_NPM**: \`${{ steps.variables.outputs.TAG_NAME_NPM }}\`
+          - **TAG_NAME_DOCKER_HELM**: \`${TAG_NAME_DOCKER_HELM}\`
+          - **TAG_NAME_MAVEN**: \`${TAG_NAME_MAVEN}\`
+          - **TAG_NAME_NPM**: \`${TAG_NAME_NPM}\`
           EOF
 
   move_mvn:

--- a/.github/workflows/nexus-artifacts-move.yml
+++ b/.github/workflows/nexus-artifacts-move.yml
@@ -37,14 +37,21 @@ jobs:
     steps:
       # https://help.sonatype.com/en/tagging.html
       - name: Get tag
+        env:
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
+          TAG: ${{ inputs.tag }}
         run: |
           curl --fail --silent --show-error \
-            --user "${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}" \
-            ${{ env.NEXUS3_URL }}/service/rest/v1/tags/${{ inputs.tag }}
+            --user "$NEXUS3_USER:$NEXUS3_PW" \
+            "$NEXUS3_URL/service/rest/v1/tags/$TAG"
 
       # https://help.sonatype.com/en/staging.html
       - name: Move artifacts
+        env:
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
+          TARGET_REPOSITORY: ${{ inputs.target_repository }}
+          TAG: ${{ inputs.tag }}
         run: |
           curl --fail --silent --show-error -X POST \
-            --user "${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}" \
-            ${{ env.NEXUS3_URL }}/service/rest/v1/staging/move/${{ inputs.target_repository }}?tag=\"${{ inputs.tag }}\"
+            --user "$NEXUS3_USER:$NEXUS3_PW" \
+            "$NEXUS3_URL/service/rest/v1/staging/move/$TARGET_REPOSITORY?tag=\"$TAG\""

--- a/.github/workflows/nexus-tag-associate.yml
+++ b/.github/workflows/nexus-tag-associate.yml
@@ -50,7 +50,12 @@ jobs:
     steps:
       # https://help.sonatype.com/en/tagging.html
       - name: Associate Components with Nexus Tag
+        env:
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
+          TAG_NAME: ${{ inputs.tag_name }}
+          REPO_ID: ${{ inputs.repo_id }}
+          VERSION: ${{ inputs.version }}
         run: |
           curl -fSs -X POST \
-          -u '${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}' \
-          '${{ env.NEXUS3_URL }}/service/rest/v1/tags/associate/${{ inputs.tag_name }}?repository=${{ inputs.repo_id }}&version=${{ inputs.version }}'
+          --user "$NEXUS3_USER:$NEXUS3_PW" \
+          "$NEXUS3_URL/service/rest/v1/tags/associate/$TAG_NAME?repository=$REPO_ID&version=$VERSION"

--- a/.github/workflows/nexus-tag-create.yml
+++ b/.github/workflows/nexus-tag-create.yml
@@ -30,9 +30,12 @@ jobs:
     steps:
       # https://help.sonatype.com/en/tagging.html
       - name: Create Nexus Tag
+        env:
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
+          NAME: ${{ inputs.name }}
         run: |
           curl -fSs -X POST \
-            --url '${{ env.NEXUS3_URL }}/service/rest/v1/tags' \
-            -u '${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}' \
+            --url "$NEXUS3_URL/service/rest/v1/tags" \
+            --user "$NEXUS3_USER:$NEXUS3_PW" \
             --header 'content-type: application/json' \
-            --data '{"name":"${{ inputs.name }}"}'
+            --data "{\"name\":\"$NAME\"}"

--- a/.github/workflows/nexus-tag-search.yml
+++ b/.github/workflows/nexus-tag-search.yml
@@ -21,7 +21,10 @@ jobs:
     steps:
       # https://help.sonatype.com/en/tagging.html
       - name: Search Components with Nexus Tag
+        env:
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
+          TAG: ${{ inputs.tag }}
         run: |
           curl -fSs -X GET \
-          -u '${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}' \
-          '${{ env.NEXUS3_URL }}/service/rest/v1/search?tag="${{ inputs.tag }}"'
+          --user "$NEXUS3_USER:$NEXUS3_PW" \
+          "$NEXUS3_URL/service/rest/v1/search?tag=\"$TAG\""

--- a/.github/workflows/nexus-tag.yml
+++ b/.github/workflows/nexus-tag.yml
@@ -109,18 +109,25 @@ jobs:
 
       - name: Set Tag Name
         id: tag
+        env:
+          TAG_NAME_INPUT: ${{ inputs.tag_name }}
+          GROUP_ID: ${{ inputs.group_id }}
+          VERSION: ${{ inputs.version }}
+          BUILD_DATE: ${{ steps.parse.outputs.build_date }}
+          RUN_ID: ${{ steps.parse.outputs.run_id }}
+          COMMIT_SHA: ${{ steps.parse.outputs.commit_sha }}
         run: |
-          TAG_NAME=${{ inputs.tag_name }}
+          TAG_NAME="$TAG_NAME_INPUT"
           if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="${{ inputs.group_id }}_${{ inputs.version }}"
+            TAG_NAME="${GROUP_ID}_${VERSION}"
           fi
 
-          TAG_NAME_MAVEN="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_MAVEN }}" # Calculate all tag names
-          TAG_NAME_DOCKER="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_DOCKER }}"
-          TAG_NAME_HELM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_HELM }}"
-          TAG_NAME_NPM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_NPM }}"
+          TAG_NAME_MAVEN="${TAG_NAME}${TAG_NAME_SUFFIX_MAVEN}" # Calculate all tag names
+          TAG_NAME_DOCKER="${TAG_NAME}${TAG_NAME_SUFFIX_DOCKER}"
+          TAG_NAME_HELM="${TAG_NAME}${TAG_NAME_SUFFIX_HELM}"
+          TAG_NAME_NPM="${TAG_NAME}${TAG_NAME_SUFFIX_NPM}"
 
-          VERSION_SUFFIX="${{ steps.parse.outputs.build_date }}-${{ steps.parse.outputs.run_id }}-${{ steps.parse.outputs.commit_sha }}"
+          VERSION_SUFFIX="${BUILD_DATE}-${RUN_ID}-${COMMIT_SHA}"
           ALL_ARTIFACTS_VERSION="*-${VERSION_SUFFIX}"
 
           cat >> $GITHUB_OUTPUT <<EOF
@@ -129,29 +136,36 @@ jobs:
           TAG_NAME_DOCKER=$TAG_NAME_DOCKER
           TAG_NAME_HELM=$TAG_NAME_HELM
           TAG_NAME_NPM=$TAG_NAME_NPM
-          STAGING_REPO_MAVEN=${{ env.STAGING_REPO_MAVEN }}
-          STAGING_REPO_DOCKER=${{ env.STAGING_REPO_DOCKER }}
-          STAGING_REPO_HELM=${{ env.STAGING_REPO_HELM }}
-          STAGING_REPO_NPM=${{ env.STAGING_REPO_NPM }}
+          STAGING_REPO_MAVEN=${STAGING_REPO_MAVEN}
+          STAGING_REPO_DOCKER=${STAGING_REPO_DOCKER}
+          STAGING_REPO_HELM=${STAGING_REPO_HELM}
+          STAGING_REPO_NPM=${STAGING_REPO_NPM}
           ALL_ARTIFACTS_VERSION=$ALL_ARTIFACTS_VERSION
           EOF
 
       - name: Summary
         shell: bash
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.TAG_NAME }}
+          TAG_NAME_MAVEN: ${{ steps.tag.outputs.TAG_NAME_MAVEN }}
+          TAG_NAME_DOCKER: ${{ steps.tag.outputs.TAG_NAME_DOCKER }}
+          TAG_NAME_HELM: ${{ steps.tag.outputs.TAG_NAME_HELM }}
+          TAG_NAME_NPM: ${{ steps.tag.outputs.TAG_NAME_NPM }}
+          ALL_ARTIFACTS_VERSION: ${{ steps.tag.outputs.ALL_ARTIFACTS_VERSION }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF  
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup Tag Name Details
           ### Outputs
-          - **TAG_NAME**: \`${{ steps.tag.outputs.TAG_NAME }}\`
-          - **TAG_NAME_MAVEN**: \`${{ steps.tag.outputs.TAG_NAME_MAVEN }}\`
-          - **TAG_NAME_DOCKER**: \`${{ steps.tag.outputs.TAG_NAME_DOCKER }}\`
-          - **TAG_NAME_HELM**: \`${{ steps.tag.outputs.TAG_NAME_HELM }}\`
-          - **TAG_NAME_NPM**: \`${{ steps.tag.outputs.TAG_NAME_NPM }}\`
-          - **STAGING_REPO_MAVEN**: \`${{ env.STAGING_REPO_MAVEN }}\`
-          - **STAGING_REPO_DOCKER**: \`${{ env.STAGING_REPO_DOCKER }}\`
-          - **STAGING_REPO_HELM**: \`${{ env.STAGING_REPO_HELM }}\`
-          - **STAGING_REPO_NPM**: \`${{ env.STAGING_REPO_NPM }}\`
-          - **ALL_ARTIFACTS_VERSION**: \`${{ steps.tag.outputs.ALL_ARTIFACTS_VERSION }}\`
+          - **TAG_NAME**: \`${TAG_NAME}\`
+          - **TAG_NAME_MAVEN**: \`${TAG_NAME_MAVEN}\`
+          - **TAG_NAME_DOCKER**: \`${TAG_NAME_DOCKER}\`
+          - **TAG_NAME_HELM**: \`${TAG_NAME_HELM}\`
+          - **TAG_NAME_NPM**: \`${TAG_NAME_NPM}\`
+          - **STAGING_REPO_MAVEN**: \`${STAGING_REPO_MAVEN}\`
+          - **STAGING_REPO_DOCKER**: \`${STAGING_REPO_DOCKER}\`
+          - **STAGING_REPO_HELM**: \`${STAGING_REPO_HELM}\`
+          - **STAGING_REPO_NPM**: \`${STAGING_REPO_NPM}\`
+          - **ALL_ARTIFACTS_VERSION**: \`${ALL_ARTIFACTS_VERSION}\`
           EOF
 
   tag_mvn:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,24 +115,34 @@ jobs:
 
       - name: Generate Workflow Run Summary
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          SEM_VER: ${{ steps.parse.outputs.sem_ver }}
+          BUILD_DATE: ${{ steps.parse.outputs.build_date }}
+          RUN_ID: ${{ steps.parse.outputs.run_id }}
+          COMMIT_SHA: ${{ steps.parse.outputs.commit_sha }}
+          MAJOR: ${{ steps.parse.outputs.major }}
+          MINOR: ${{ steps.parse.outputs.minor }}
+          PATCH: ${{ steps.parse.outputs.patch }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ### Inputs
-          - **version**: \`${{ inputs.version }}\`
-          - **target_branch**: \`${{ inputs.target_branch }}\`
+          - **version**: \`$VERSION\`
+          - **target_branch**: \`$TARGET_BRANCH\`
 
           ## Parse Version
           ### Outputs
-          - **SEM_VER**: \`${{ steps.parse.outputs.SEM_VER }}\`
-          - **BUILD_DATE**: \`${{ steps.parse.outputs.BUILD_DATE }}\`
-          - **RUN_ID**: \`${{ steps.parse.outputs.RUN_ID }}\`
-          - **COMMIT_SHA**: \`${{ steps.parse.outputs.COMMIT_SHA }}\`
+          - **SEM_VER**: \`$SEM_VER\`
+          - **BUILD_DATE**: \`$BUILD_DATE\`
+          - **RUN_ID**: \`$RUN_ID\`
+          - **COMMIT_SHA**: \`$COMMIT_SHA\`
 
           ## Parse SemVer
           ### Outputs
-          - **MAJOR**: \`${{ steps.parse.outputs.MAJOR }}\`
-          - **MINOR**: \`${{ steps.parse.outputs.MINOR }}\`
-          - **PATCH**: \`${{ steps.parse.outputs.PATCH }}\`
+          - **MAJOR**: \`$MAJOR\`
+          - **MINOR**: \`$MINOR\`
+          - **PATCH**: \`$PATCH\`
           EOF
 
   promote:
@@ -225,8 +235,11 @@ jobs:
 
   announce:
     name: Announce new release
-    # Policy: Only announce if all required release steps completed without failure
-    if: ${{ inputs.send_announcement }}
+    # Policy: Only announce if all required release steps completed without failure.
+    # `always()` is required because several needed jobs (promote, git-tag, jira-release,
+    # archetype) are conditionally skipped on a normal release; without it this job would
+    # itself be skipped whenever any upstream job is skipped.
+    if: ${{ always() && inputs.send_announcement && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     needs:
       - setup
       - promote

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,11 +235,12 @@ jobs:
 
   announce:
     name: Announce new release
-    # Policy: Only announce if all required release steps completed without failure.
+    # Policy: Only announce if the workflow was not cancelled and all required release
+    # steps completed without failure.
     # `always()` is required because several needed jobs (promote, git-tag, jira-release,
     # archetype) are conditionally skipped on a normal release; without it this job would
     # itself be skipped whenever any upstream job is skipped.
-    if: ${{ always() && inputs.send_announcement && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !cancelled() && inputs.send_announcement && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     needs:
       - setup
       - promote

--- a/.github/workflows/shared-deploy-dev.yml
+++ b/.github/workflows/shared-deploy-dev.yml
@@ -82,19 +82,28 @@ jobs:
           path: deployment-repo
 
       - name: Configure Git User Identity
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           cd deployment-repo
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Update Version and Push to Deployment Repo
+        env:
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           cd deployment-repo
-          ./updateVersion.sh "${{ inputs.component_name }}" "${{ inputs.version }}"
-          git push origin ${{ inputs.branch }}
+          ./updateVersion.sh "$COMPONENT_NAME" "$VERSION"
+          git push origin "$BRANCH"
 
       - name: Generate Deployment Summary
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           echo "## Deploy DEV Details" >> $GITHUB_STEP_SUMMARY
-          echo "- **version**: \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **branch**: \`${{ inputs.branch }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **version**: \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **branch**: \`$BRANCH\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/shared-maven-build.yml
+++ b/.github/workflows/shared-maven-build.yml
@@ -111,8 +111,10 @@ jobs:
 
       - name: Unlock macOS Keychain (for code signing)
         if: ${{ contains(runner.name, 'macduff') }}
+        env:
+          MACDUFF_KEYCHAIN_PASSWORD: ${{ secrets.MACDUFF_KEYCHAIN_PASSWORD }}
         run: |
-          security unlock-keychain -p "${{ secrets.MACDUFF_KEYCHAIN_PASSWORD }}"
+          security unlock-keychain -p "$MACDUFF_KEYCHAIN_PASSWORD"
           security list-keychains
 
       - name: Login to Uniport Docker Registry
@@ -200,11 +202,14 @@ jobs:
           lcov: frontend/src/main/web/coverage/lcov.info
 
       - name: Generate Build Summary for GitHub UI
+        env:
+          RC_VERSION: ${{ steps.vars.outputs.RC_VERSION }}
+          GROUP_ID: ${{ steps.vars.outputs.GROUP_ID }}
         run: |
           cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Maven Build
           | Output | Value |
           |--------|-------|
-          | VERSION | \`${{ steps.vars.outputs.RC_VERSION }}\` |
-          | GROUP_ID | \`${{ steps.vars.outputs.GROUP_ID }}\` |
+          | VERSION | \`$RC_VERSION\` |
+          | GROUP_ID | \`$GROUP_ID\` |
           EOF

--- a/.github/workflows/shared-nexus-tag-artifacts.yml
+++ b/.github/workflows/shared-nexus-tag-artifacts.yml
@@ -119,10 +119,17 @@ jobs:
 
       - name: Generate Standardized Nexus Tag Names
         id: setup
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          GROUP_ID: ${{ inputs.group_id }}
+          VERSION: ${{ inputs.version }}
+          PARSE_BUILD_DATE: ${{ steps.parse.outputs.build_date }}
+          PARSE_RUN_ID: ${{ steps.parse.outputs.run_id }}
+          PARSE_COMMIT_SHA: ${{ steps.parse.outputs.commit_sha }}
         run: |
-          TAG_NAME=${{ inputs.tag_name }}
+          TAG_NAME="$INPUT_TAG_NAME"
           if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="${{ inputs.group_id }}_${{ inputs.version }}"
+            TAG_NAME="${GROUP_ID}_${VERSION}"
           fi
 
           echo "Base tag name: $TAG_NAME"
@@ -135,7 +142,7 @@ jobs:
           # Calculate the version pattern used to find Maven artifacts in Nexus based on build metadata.
           # The leading wildcard is intentional — associate workflow detects it and uses q= instead of version=,
           # which handles multi-module builds where modules share the same build suffix but have different version prefixes.
-          VERSION_SUFFIX="${{ steps.parse.outputs.build_date }}-${{ steps.parse.outputs.run_id }}-${{ steps.parse.outputs.commit_sha }}"
+          VERSION_SUFFIX="${PARSE_BUILD_DATE}-${PARSE_RUN_ID}-${PARSE_COMMIT_SHA}"
           ALL_ARTIFACTS_VERSION="*-${VERSION_SUFFIX}"
 
           echo "Maven version pattern: $ALL_ARTIFACTS_VERSION"
@@ -156,20 +163,27 @@ jobs:
 
       - name: Generate Tag Configuration Summary
         shell: bash
+        env:
+          OUT_TAG_NAME: ${{ steps.setup.outputs.TAG_NAME }}
+          OUT_TAG_NAME_MAVEN: ${{ steps.setup.outputs.TAG_NAME_MAVEN }}
+          OUT_TAG_NAME_DOCKER: ${{ steps.setup.outputs.TAG_NAME_DOCKER }}
+          OUT_TAG_NAME_HELM: ${{ steps.setup.outputs.TAG_NAME_HELM }}
+          OUT_TAG_NAME_NPM: ${{ steps.setup.outputs.TAG_NAME_NPM }}
+          OUT_ALL_ARTIFACTS_VERSION: ${{ steps.setup.outputs.ALL_ARTIFACTS_VERSION }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF  
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup Tag Name Details
           ### Outputs
-          - **TAG_NAME**: \`${{ steps.setup.outputs.TAG_NAME }}\`
-          - **TAG_NAME_MAVEN**: \`${{ steps.setup.outputs.TAG_NAME_MAVEN }}\`
-          - **TAG_NAME_DOCKER**: \`${{ steps.setup.outputs.TAG_NAME_DOCKER }}\`
-          - **TAG_NAME_HELM**: \`${{ steps.setup.outputs.TAG_NAME_HELM }}\`
-          - **TAG_NAME_NPM**: \`${{ steps.setup.outputs.TAG_NAME_NPM }}\`
+          - **TAG_NAME**: \`$OUT_TAG_NAME\`
+          - **TAG_NAME_MAVEN**: \`$OUT_TAG_NAME_MAVEN\`
+          - **TAG_NAME_DOCKER**: \`$OUT_TAG_NAME_DOCKER\`
+          - **TAG_NAME_HELM**: \`$OUT_TAG_NAME_HELM\`
+          - **TAG_NAME_NPM**: \`$OUT_TAG_NAME_NPM\`
           - **STAGING_REPO_MAVEN**: \`${{ env.STAGING_REPO_MAVEN }}\`
           - **STAGING_REPO_DOCKER**: \`${{ env.STAGING_REPO_DOCKER }}\`
           - **STAGING_REPO_HELM**: \`${{ env.STAGING_REPO_HELM }}\`
           - **STAGING_REPO_NPM**: \`${{ env.STAGING_REPO_NPM }}\`
-          - **ALL_ARTIFACTS_VERSION**: \`${{ steps.setup.outputs.ALL_ARTIFACTS_VERSION }}\`
+          - **ALL_ARTIFACTS_VERSION**: \`$OUT_ALL_ARTIFACTS_VERSION\`
           EOF
 
   # Create tags for enabled artifact types

--- a/.github/workflows/shared-nexus-tag-associate.yml
+++ b/.github/workflows/shared-nexus-tag-associate.yml
@@ -52,13 +52,18 @@ jobs:
     steps:
       # https://help.sonatype.com/en/tagging.html
       - name: Associate Components with Nexus Tag
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+          REPO_ID: ${{ inputs.repo_id }}
+          INPUT_VERSION: ${{ inputs.version }}
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
         run: |
-          echo "Associating components with tag: ${{ inputs.tag_name }}"
-          echo "Associating components in repository '${{ inputs.repo_id }}' with version pattern '${{ inputs.version }}'"
+          echo "Associating components with tag: $TAG_NAME"
+          echo "Associating components in repository '$REPO_ID' with version pattern '$INPUT_VERSION'"
 
           # If the version starts with a wildcard (e.g. "*-suffix"), strip it and use keyword search (q=)
           # directly on the associate endpoint — Nexus 3.88+ dropped wildcard support on version= but q= works.
-          VERSION="${{ inputs.version }}"
+          VERSION="$INPUT_VERSION"
           if [[ "$VERSION" == \** ]]; then
             SEARCH_PARAM="q"
             SEARCH_VALUE="${VERSION#\*-}"
@@ -69,8 +74,8 @@ jobs:
           echo "Using search parameter: ${SEARCH_PARAM}=${SEARCH_VALUE}"
 
           HTTP_CODE=$(curl -fSs -w "%{http_code}" -o /tmp/response.json -X POST \
-            -u '${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}' \
-            "${{ env.NEXUS3_URL }}/service/rest/v1/tags/associate/${{ inputs.tag_name }}?repository=${{ inputs.repo_id }}&${SEARCH_PARAM}=${SEARCH_VALUE}")
+            --user "${{ env.NEXUS3_USER }}:$NEXUS3_PW" \
+            "${{ env.NEXUS3_URL }}/service/rest/v1/tags/associate/$TAG_NAME?repository=$REPO_ID&${SEARCH_PARAM}=${SEARCH_VALUE}")
 
           if [ "$HTTP_CODE" -eq 200 ]; then
             echo "✓ Successfully associated all components with tag"

--- a/.github/workflows/shared-nexus-tag-create.yml
+++ b/.github/workflows/shared-nexus-tag-create.yml
@@ -33,27 +33,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Tag Name
+        env:
+          NAME: ${{ inputs.name }}
         run: |
-          if [ -z "${{ inputs.name }}" ]; then
+          if [ -z "$NAME" ]; then
             echo "Error: Tag name is required"
             exit 1
           fi
 
           # Check for invalid characters in tag name
-           if echo "${{ inputs.name }}" | grep -qE '[^a-zA-Z0-9._-]'; then
+           if echo "$NAME" | grep -qE '[^a-zA-Z0-9._-]'; then
              echo "Warning: Tag name contains special characters that may cause issues"
            fi
 
       # https://help.sonatype.com/en/tagging.html
       - name: Create Nexus Tag
+        env:
+          NAME: ${{ inputs.name }}
+          NEXUS3_PW: ${{ secrets.NEXUS3_PW }}
         run: |
-          echo "Creating tag: ${{ inputs.name }}"
+          echo "Creating tag: $NAME"
 
           HTTP_CODE=$(curl -fSs -w "%{http_code}" -o /tmp/response.json -X POST \
-            --url '${{ env.NEXUS3_URL }}/service/rest/v1/tags' \
-            -u '${{ env.NEXUS3_USER }}:${{ secrets.NEXUS3_PW }}' \
+            --url "${{ env.NEXUS3_URL }}/service/rest/v1/tags" \
+            --user "${{ env.NEXUS3_USER }}:$NEXUS3_PW" \
             --header 'content-type: application/json' \
-            --data '{"name":"${{ inputs.name }}"}')
+            --data "{\"name\":\"$NAME\"}")
 
           if [ "$HTTP_CODE" -eq 200 ]; then
             echo "✓ Successfully created tag"

--- a/.github/workflows/shared-update-archetype.yml
+++ b/.github/workflows/shared-update-archetype.yml
@@ -75,13 +75,19 @@ jobs:
           path: archetype-repo
 
       - name: Configure Git User Identity
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           cd archetype-repo
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Register Version and Push to Archetype Repo
+        env:
+          COMMAND: ${{ inputs.command }}
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          VERSION: ${{ inputs.version }}
         run: |
           cd archetype-repo
-          ./registerVersion.sh ${{ inputs.command }} "${{ inputs.component_name }}" ${{ inputs.version }}
+          ./registerVersion.sh "$COMMAND" "$COMPONENT_NAME" "$VERSION"
           git push origin master

--- a/.github/workflows/tag-nexus-artifacts.yml
+++ b/.github/workflows/tag-nexus-artifacts.yml
@@ -108,18 +108,25 @@ jobs:
 
       - name: Set Tag Name
         id: tag
+        env:
+          TAG_NAME_INPUT: ${{ inputs.tag_name }}
+          GROUP_ID: ${{ inputs.group_id }}
+          VERSION: ${{ inputs.version }}
+          BUILD_DATE: ${{ steps.parse.outputs.build_date }}
+          RUN_ID: ${{ steps.parse.outputs.run_id }}
+          COMMIT_SHA: ${{ steps.parse.outputs.commit_sha }}
         run: |
-          TAG_NAME=${{ inputs.tag_name }}
+          TAG_NAME="$TAG_NAME_INPUT"
           if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="${{ inputs.group_id }}_${{ inputs.version }}"
+            TAG_NAME="${GROUP_ID}_${VERSION}"
           fi
 
-          TAG_NAME_MAVEN="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_MAVEN }}" # Calculate all tag names
-          TAG_NAME_DOCKER="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_DOCKER }}"
-          TAG_NAME_HELM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_HELM }}"
-          TAG_NAME_NPM="${TAG_NAME}${{ env.TAG_NAME_SUFFIX_NPM }}"
+          TAG_NAME_MAVEN="${TAG_NAME}${TAG_NAME_SUFFIX_MAVEN}" # Calculate all tag names
+          TAG_NAME_DOCKER="${TAG_NAME}${TAG_NAME_SUFFIX_DOCKER}"
+          TAG_NAME_HELM="${TAG_NAME}${TAG_NAME_SUFFIX_HELM}"
+          TAG_NAME_NPM="${TAG_NAME}${TAG_NAME_SUFFIX_NPM}"
 
-          VERSION_SUFFIX="${{ steps.parse.outputs.build_date }}-${{ steps.parse.outputs.run_id }}-${{ steps.parse.outputs.commit_sha }}"
+          VERSION_SUFFIX="${BUILD_DATE}-${RUN_ID}-${COMMIT_SHA}"
           ALL_ARTIFACTS_VERSION="*-${VERSION_SUFFIX}"
 
           cat >> $GITHUB_OUTPUT <<EOF
@@ -128,29 +135,36 @@ jobs:
           TAG_NAME_DOCKER=$TAG_NAME_DOCKER
           TAG_NAME_HELM=$TAG_NAME_HELM
           TAG_NAME_NPM=$TAG_NAME_NPM
-          STAGING_REPO_MAVEN=${{ env.STAGING_REPO_MAVEN }}
-          STAGING_REPO_DOCKER=${{ env.STAGING_REPO_DOCKER }}
-          STAGING_REPO_HELM=${{ env.STAGING_REPO_HELM }}
-          STAGING_REPO_NPM=${{ env.STAGING_REPO_NPM }}
+          STAGING_REPO_MAVEN=${STAGING_REPO_MAVEN}
+          STAGING_REPO_DOCKER=${STAGING_REPO_DOCKER}
+          STAGING_REPO_HELM=${STAGING_REPO_HELM}
+          STAGING_REPO_NPM=${STAGING_REPO_NPM}
           ALL_ARTIFACTS_VERSION=$ALL_ARTIFACTS_VERSION
           EOF
 
       - name: Summary
         shell: bash
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.TAG_NAME }}
+          TAG_NAME_MAVEN: ${{ steps.tag.outputs.TAG_NAME_MAVEN }}
+          TAG_NAME_DOCKER: ${{ steps.tag.outputs.TAG_NAME_DOCKER }}
+          TAG_NAME_HELM: ${{ steps.tag.outputs.TAG_NAME_HELM }}
+          TAG_NAME_NPM: ${{ steps.tag.outputs.TAG_NAME_NPM }}
+          ALL_ARTIFACTS_VERSION: ${{ steps.tag.outputs.ALL_ARTIFACTS_VERSION }}
         run: |
           cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup Tag Name Details
           ### Outputs
-          - **TAG_NAME**: \`${{ steps.tag.outputs.TAG_NAME }}\`
-          - **TAG_NAME_MAVEN**: \`${{ steps.tag.outputs.TAG_NAME_MAVEN }}\`
-          - **TAG_NAME_DOCKER**: \`${{ steps.tag.outputs.TAG_NAME_DOCKER }}\`
-          - **TAG_NAME_HELM**: \`${{ steps.tag.outputs.TAG_NAME_HELM }}\`
-          - **TAG_NAME_NPM**: \`${{ steps.tag.outputs.TAG_NAME_NPM }}\`
-          - **STAGING_REPO_MAVEN**: \`${{ env.STAGING_REPO_MAVEN }}\`
-          - **STAGING_REPO_DOCKER**: \`${{ env.STAGING_REPO_DOCKER }}\`
-          - **STAGING_REPO_HELM**: \`${{ env.STAGING_REPO_HELM }}\`
-          - **STAGING_REPO_NPM**: \`${{ env.STAGING_REPO_NPM }}\`
-          - **ALL_ARTIFACTS_VERSION**: \`${{ steps.tag.outputs.ALL_ARTIFACTS_VERSION }}\`
+          - **TAG_NAME**: \`${TAG_NAME}\`
+          - **TAG_NAME_MAVEN**: \`${TAG_NAME_MAVEN}\`
+          - **TAG_NAME_DOCKER**: \`${TAG_NAME_DOCKER}\`
+          - **TAG_NAME_HELM**: \`${TAG_NAME_HELM}\`
+          - **TAG_NAME_NPM**: \`${TAG_NAME_NPM}\`
+          - **STAGING_REPO_MAVEN**: \`${STAGING_REPO_MAVEN}\`
+          - **STAGING_REPO_DOCKER**: \`${STAGING_REPO_DOCKER}\`
+          - **STAGING_REPO_HELM**: \`${STAGING_REPO_HELM}\`
+          - **STAGING_REPO_NPM**: \`${STAGING_REPO_NPM}\`
+          - **ALL_ARTIFACTS_VERSION**: \`${ALL_ARTIFACTS_VERSION}\`
           EOF
 
   tag_mvn:

--- a/.github/workflows/update-archetype.yml
+++ b/.github/workflows/update-archetype.yml
@@ -68,13 +68,19 @@ jobs:
           path: archetype-repo
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           cd archetype-repo
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Register version
+        env:
+          COMMAND: ${{ inputs.command }}
+          COMPONENT_NAME: ${{ inputs.component_name }}
+          VERSION: ${{ inputs.version }}
         run: |
           cd archetype-repo
-          ./registerVersion.sh ${{ inputs.command }} "${{ inputs.component_name }}" ${{ inputs.version }}
+          ./registerVersion.sh "$COMMAND" "$COMPONENT_NAME" "$VERSION"
           git push origin master

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -52,19 +52,23 @@ jobs:
       - name: Setup
         id: setup
         shell: bash
+        env:
+          MAJOR: ${{ inputs.major }}
+          MINOR: ${{ inputs.minor }}
+          PATCH: ${{ inputs.patch }}
         run: |
           set -u
 
-          NEXT_MINOR="${{ inputs.minor }}"
-          NEXT_PATCH="${{ inputs.patch }}"
+          NEXT_MINOR="$MINOR"
+          NEXT_PATCH="$PATCH"
 
-          if [[ "${{ inputs.patch }}" -eq 0 ]]; then
-            NEXT_MINOR="$(( ${{ inputs.minor }} + 1 ))"
+          if [[ "$PATCH" -eq 0 ]]; then
+            NEXT_MINOR="$(( MINOR + 1 ))"
           else
-            NEXT_PATCH="$(( ${{ inputs.patch }} + 1 ))"
+            NEXT_PATCH="$(( PATCH + 1 ))"
           fi
 
-          NEXT_VERSION="${{ inputs.major }}.${NEXT_MINOR}.${NEXT_PATCH}"
+          NEXT_VERSION="$MAJOR.${NEXT_MINOR}.${NEXT_PATCH}"
 
           cat >> $GITHUB_OUTPUT <<EOF  
           NEXT_VERSION=$NEXT_VERSION
@@ -77,9 +81,11 @@ jobs:
           ref: ${{ inputs.branch_name }}
 
       - name: Configure Git user
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "$ACTOR"
+          git config user.email "$ACTOR@users.noreply.github.com"
 
       - name: Bump version
         uses: uniport/workflows/.github/actions/set-version@main
@@ -87,6 +93,8 @@ jobs:
           version: ${{ steps.setup.outputs.NEXT_VERSION }}-${{ env.SNAPSHOT_SUFFIX }}
 
       - name: Commit
+        env:
+          NEXT_VERSION: ${{ steps.setup.outputs.NEXT_VERSION }}
         run: |
           git add $(find . -name 'pom.xml')
           git add $(find . -path '**/web/package.json') || echo "No package.json found"
@@ -95,22 +103,30 @@ jobs:
           # only commit if there are changes
           git diff-index --quiet HEAD || git commit \
             --no-verify \
-            --message "Set version to ${{ steps.setup.outputs.NEXT_VERSION }}"
+            --message "Set version to $NEXT_VERSION"
 
       - name: Push
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
         run: |
-          git push origin ${{ inputs.branch_name }}
+          git push origin "$BRANCH_NAME"
 
       - name: Summary
         shell: bash
+        env:
+          MAJOR: ${{ inputs.major }}
+          MINOR: ${{ inputs.minor }}
+          PATCH: ${{ inputs.patch }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          NEXT_VERSION: ${{ steps.setup.outputs.NEXT_VERSION }}
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF  
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
           ## Setup
           ### Inputs
-          - **major**: \`${{ inputs.major }}\`          
-          - **minor**: \`${{ inputs.minor }}\`          
-          - **patch**: \`${{ inputs.patch }}\`          
-          - **branch_name**: \`${{ inputs.branch_name }}\`          
+          - **major**: \`$MAJOR\`
+          - **minor**: \`$MINOR\`
+          - **patch**: \`$PATCH\`
+          - **branch_name**: \`$BRANCH_NAME\`
           ### Outputs
-          - **NEXT_VERSION**: \`${{ steps.setup.outputs.NEXT_VERSION }}\`
+          - **NEXT_VERSION**: \`$NEXT_VERSION\`
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added workflows and actions for running the release pipeline with github actions ([PORTAL-1673](https://inventage-all.atlassian.net/browse/PORTAL-1673))
 
+### Fixed
+
+- The release `announce` job is no longer skipped when optional upstream jobs (promote, git-tag, jira-release, archetype) are skipped; its condition now uses `always()` and only suppresses the announcement on failure or cancellation.
+- The release workflow run summary now renders the parsed version metadata correctly (it previously referenced non-existent uppercase `parse` outputs and rendered blank).
+
+### Security
+
+- Hardened all reusable workflows and composite actions against shell script injection: every `github.*`, `inputs.*`, `secrets.*`, and `vars.*` value interpolated into a `run:` step is now passed via `env:` and referenced as a quoted shell variable. Removed the `eval` in the Add Helm Repositories action (now a bash argument array) and moved Nexus, macOS keychain, skopeo, and Jira credentials off command lines. Removed the step that printed the generated `.npmrc` auth token to the build log.
+
 [unreleased]: https://github.com/uniport/workflows/compare/73134d30c856eaabc9c891492f265b896517382c...main


### PR DESCRIPTION
## Summary

Hardens every reusable workflow and composite action against shell **script injection**, and fixes two release-workflow correctness bugs found during the review.

The core change is mechanical and repo-wide: every `github.*`, `inputs.*`, `secrets.*`, and `vars.*` value that was interpolated directly into a `run:` shell body is now passed via a step-level `env:` block and referenced as a **quoted shell variable**. This is the standard mitigation for [GitHub Actions expression injection](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Security

- **Script injection**: all untrusted `${{ … }}` moved out of `run:` bodies into `env:` (quoted refs) across every workflow + composite action.
- **Secrets off command lines**: Nexus credentials (`curl --user`), macOS keychain password, skopeo `--src/--dest-creds`, and the Jira auth token are no longer interpolated into command strings.
- **`add-helm-repositories`**: removed `eval` of a built-up command string; now uses a bash argument array.
- **`setup-npm-nexus-access`**: removed the step that printed the generated `.npmrc` (auth token) to the build log.

## Fixed

- **Release `announce` job** was effectively never running: its condition was just `inputs.send_announcement` while it `needs:` several jobs that are skipped on a normal release, so it got skipped too. Now gated with `always() && … && !contains(needs.*.result, 'failure'/'cancelled')`.
- **Release run summary** referenced non-existent uppercase `parse` outputs (rendered blank); now uses the correct lowercase outputs.

## Verification

- `actionlint` clean across the tree (only the pre-existing `macduff` self-hosted-runner label warning).
- Injection scan confirms no untrusted `inputs.*`/`secrets.*`/`github.event.*` remains in any `run:` body. Remaining `${{ }}` occurrences are safe (`with:`/`env:` values, the announce `message:` hardened inside its action, and a fixed-literal ternary in `shared-maven-build.yml`).

## Notes / not in this PR

- This repo has **no release/tag process** — consumers ride `@main`, and `package.json`'s `1.0.0` maps to no tag. The CHANGELOG entry is under `[Unreleased]`. Cutting an actual `v1.0.0` (so this lands in a real release) is a separate decision.
- Scope was deliberately limited to injection/secrets + the announce gating. Other review findings (missing `permissions:` blocks, `concurrency` groups, unpinned third-party actions, the orphaned `shared-*` vs legacy duplication, the dead non-dot `github/` dir, README link errors) are **not** addressed here.