### PR TITLE
fix(ci): check out PR head in shared maven build under pull_request_target

### DIFF
--- a/.github/workflows/shared-maven-build.yml
+++ b/.github/workflows/shared-maven-build.yml
@@ -90,6 +90,10 @@ jobs:
         with:
           # fetch-depth: 0 is required for spotless-maven-plugin branch comparisons
           fetch-depth: 0
+          # Under pull_request_target the default ref is the base branch, which
+          # would build base instead of the PR's proposed changes. Pin to the PR
+          # head when available; fall back to github.sha for push/dispatch.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Build Variables (RC Versioning)
         id: vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added workflows and actions for running the release pipeline with github actions ([PORTAL-1673](https://inventage-all.atlassian.net/browse/PORTAL-1673))
 
+### Fixed
+
+- `shared-maven-build.yml` now checks out the PR head under `pull_request_target` so Dependabot PR builds verify the proposed changes instead of the base branch
+
 [unreleased]: https://github.com/uniport/workflows/compare/73134d30c856eaabc9c891492f265b896517382c...main


### PR DESCRIPTION
## Why

`shared-maven-build.yml`'s checkout step has no explicit `ref`, so under `pull_request_target` it resolves to the base branch's tip. Every Dependabot PR's CI has therefore been building **the base branch**, not the proposed changes — the green checkmark only confirmed that master still builds, not that the bump was viable.

The bug stayed invisible for most bumps (a `pom.xml` version diff alone resolves fine against the base tree), but it surfaced now for `code-style-settings`: that artifact ships generated files (`hooks/pre-push`, `portal-java-formatter.xml`, …) which the build unpacks over the tree, and any unsynced commit at base trips the post-build `ensure-no-uncommitted-code` check.

## Change

Pin `ref` to the PR head when available, falling back to `github.sha`:

```yaml
ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

- `pull_request_target` → PR head (the fix)
- `push` / `workflow_dispatch` / `schedule` → `github.sha`, identical to today

Only `pull_request_target` callers (the 20 repos' `dependabot-pr.yml`) see new behavior. Acceptable here because the trigger is already gated to `github.event.pull_request.user.login == 'dependabot[bot]'`, and Dependabot is first-party.