### PR TITLE
Publish static analysis reports before failing, skip when analysis cannot run

### DIFF
--- a/.github/actions/base/publish-checkstyle-report/action.yml
+++ b/.github/actions/base/publish-checkstyle-report/action.yml
@@ -14,7 +14,12 @@ runs:
   using: composite
   steps:
     - name: Run Checkstyle
+      id: checkstyle_analysis
       shell: bash
+      # Deferred failure (see last step): the report must still be published when the check
+      # finds violations, and the action must not fail when an earlier build failure (e.g.
+      # unresolvable dependencies) prevents the analysis from running at all.
+      continue-on-error: true
       run: |
         mvn -B -V --no-transfer-progress --settings ${{ inputs.settings_file }} initialize checkstyle:check
 
@@ -36,3 +41,13 @@ runs:
 
     - name: Checkstyle Summary
       uses: uniport/workflows/.github/actions/base/checkstyle-summary@main
+
+    - name: Evaluate Checkstyle outcome
+      if: ${{ steps.checkstyle_analysis.outcome == 'failure' }}
+      shell: bash
+      run: |
+        if [ "${{ steps.checkstyle_results.outputs.found }}" = "true" ]; then
+          echo "::error::Checkstyle check failed, see the published report and the job summary"
+          exit 1
+        fi
+        echo "::notice::Checkstyle analysis could not run and produced no results, most likely because a previous build step failed; skipping report"

--- a/.github/actions/base/publish-spotbugs-report/action.yml
+++ b/.github/actions/base/publish-spotbugs-report/action.yml
@@ -14,7 +14,12 @@ runs:
   using: composite
   steps:
     - name: Run SpotBugs
+      id: spotbugs_analysis
       shell: bash
+      # Deferred failure (see last step): the report must still be published when the check
+      # finds bugs, and the action must not fail when an earlier build failure (e.g.
+      # unresolvable dependencies) prevents the analysis from running at all.
+      continue-on-error: true
       run: |
         mvn -B -V --no-transfer-progress --settings ${{ inputs.settings_file }} initialize spotbugs:check
 
@@ -36,3 +41,13 @@ runs:
 
     - name: SpotBugs Summary
       uses: uniport/workflows/.github/actions/base/spotbugs-summary@main
+
+    - name: Evaluate SpotBugs outcome
+      if: ${{ steps.spotbugs_analysis.outcome == 'failure' }}
+      shell: bash
+      run: |
+        if [ "${{ steps.spotbugs_results.outputs.found }}" = "true" ]; then
+          echo "::error::SpotBugs check failed, see the published report and the job summary"
+          exit 1
+        fi
+        echo "::notice::SpotBugs analysis could not run and produced no results, most likely because a previous build step failed; skipping report"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `shared-maven-build.yml` now checks out the PR head under `pull_request_target` so Dependabot PR builds verify the proposed changes instead of the base branch
+- `publish-spotbugs-report` and `publish-checkstyle-report` now publish the report before failing on violations, and no longer add a confusing secondary failure when the analysis cannot run because an earlier build step failed (e.g. unresolvable dependencies) ([GH-50](https://github.com/uniport/workflows/pull/50))
 
 [unreleased]: https://github.com/uniport/workflows/compare/73134d30c856eaabc9c891492f265b896517382c...main


### PR DESCRIPTION
## Summary

The `publish-spotbugs-report` and `publish-checkstyle-report` actions re-run Maven (`initialize spotbugs:check` / `checkstyle:check`) to produce their reports. Two problems with the current behavior:

- When the preceding *Execute Maven deploy* step fails early (e.g. unresolvable dependencies), the analysis fails for the same reason and the job shows a confusing **secondary** "Publish SpotBugs Vulnerability Results" error that has nothing to do with SpotBugs. Example: [notification PR 74 build](https://github.com/uniport/notification/actions/runs/29243233389/job/86793976124?pr=74).
- When the analysis genuinely finds violations, `spotbugs:check` failed the composite **before** the report was published - the report was missing exactly when it was needed.

Both actions now defer the failure decision to a final step:

| Analysis outcome | Results present | Behavior |
|---|---|---|
| success | - | unchanged (publish + summary) |
| failure | yes | publish report + summary **first**, then fail with a pointer to the report |
| failure | no | log a notice and stay green - the failed build step remains the single loud failure |

Note: consumers reference these actions `@main`, so the behavior applies to all repos using the shared pipeline on merge.