### PR TITLE
feat(ci): add shared Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/shared-dependabot-automerge.yml
+++ b/.github/workflows/shared-dependabot-automerge.yml
@@ -1,0 +1,113 @@
+# Shared Dependabot Auto-Merge Workflow
+#
+# Approves and merges Dependabot pull requests that
+#   1. were verified by the calling workflow (callers MUST gate this job on
+#      their build job via 'needs'),
+#   2. belong to a dependency group from the repository's dependabot.yml that
+#      is allowlisted in the 'merge_policy' input, and
+#   3. bump at most the update type configured for that group (majors always
+#      require a human; for grouped PRs the update type is the highest bump
+#      contained in the group).
+#
+# The default policy reflects historical merge behavior across uniport repos:
+# Quarkus is patch-only (LTS policy; patches were merged 100% of the time),
+# build tooling is safe up to minor (>80% merged), jOOQ minors touch the
+# Quarkiverse extension compatibility so they stay manual, and test
+# dependencies are deliberately absent - history shows they are almost always
+# deferred by a human (often because they must match the Quarkus BOM). For npm,
+# UI runtime dependencies auto-merge patches only (minors can change the UI in
+# ways automated tests miss) while dev tooling auto-merges up to minor since it
+# is fully exercised by build + lint + tests.
+#
+# Technical Details:
+# - Callers must trigger on 'pull_request_target' so this policy always runs
+#   from the default branch and cannot be altered from within the PR itself.
+# - The job is restricted to the 'dependabot[bot]' actor; a human pushing
+#   additional commits to a Dependabot branch changes the actor and disarms it.
+#   The merge is performed immediately (GitHub's 'auto-merge' is deliberately
+#   not armed on the PR), so after a human fix a later green build never merges
+#   the PR behind their back - humans merge such PRs manually. Commenting
+#   '@dependabot rebase' hands the branch back to the bot and re-arms auto-merge.
+# - The merge is performed with a Uniport GitHub App token instead of
+#   GITHUB_TOKEN, so the resulting push still triggers the regular pipelines
+#   on the default branch. The App needs 'Contents: write' and
+#   'Pull requests: write' on the repository.
+# - Merge method is rebase to match how Dependabot PRs are merged manually.
+
+name: '# Shared-Dependabot-Automerge'
+
+on:
+  workflow_call:
+    inputs:
+      merge_policy:
+        description: >-
+          Comma-separated <group>:<max-update-type> pairs. Only PRs of an
+          allowlisted dependabot.yml dependency group whose highest bump is at
+          most the configured type (patch|minor) are auto-merged.
+        type: string
+        required: false
+        default: 'quarkus:patch,build-tooling:minor,jooq:patch,actions:minor,frontend-runtime-patch:patch,frontend-tooling:minor'
+    secrets:
+      UNIPORT_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  automerge:
+    name: Auto-Merge
+    runs-on: macduff
+    if: ${{ github.actor == 'dependabot[bot]' }} # Ensure this only runs for bot-initiated PRs
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Evaluate merge policy
+        id: policy
+        env:
+          MERGE_POLICY: ${{ inputs.merge_policy }}
+          # Ungrouped PRs have an empty dependency-group and are never auto-merged
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          eligible=false
+          if [ -n "$GROUP" ]; then
+            IFS=',' read -ra rules <<< "$MERGE_POLICY"
+            for rule in "${rules[@]}"; do
+              group="${rule%%:*}"
+              max_type="${rule##*:}"
+              if [ "$group" != "$GROUP" ]; then
+                continue
+              fi
+              case "$UPDATE_TYPE" in
+                version-update:semver-patch)
+                  eligible=true
+                  ;;
+                version-update:semver-minor)
+                  if [ "$max_type" = "minor" ]; then
+                    eligible=true
+                  fi
+                  ;;
+              esac
+            done
+          fi
+          echo "Group '${GROUP:-<none>}' with update type '$UPDATE_TYPE' -> eligible=$eligible"
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate as Uniport GitHub App
+        id: app-token
+        if: ${{ steps.policy.outputs.eligible == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.UNIPORT_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.UNIPORT_APP_PRIVATE_KEY }}
+
+      - name: Approve and merge
+        if: ${{ steps.app-token.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --rebase "$PR_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added workflows and actions for running the release pipeline with github actions ([PORTAL-1673](https://inventage-all.atlassian.net/browse/PORTAL-1673))
+- Added `shared-dependabot-automerge.yml`: approves and rebase-merges Dependabot PRs after the calling repository's build passed, based on a per-group merge policy (`merge_policy` input; majors, test dependencies and ungrouped/internal dependencies always stay human-reviewed). Merges as the Uniport GitHub App so the regular pipelines on the default branch still trigger; any human commit on a Dependabot branch disarms auto-merge ([GH-51](https://github.com/uniport/workflows/pull/51))
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Adds a reusable workflow that approves and rebase-merges Dependabot PRs after the calling repository's build has passed, based on a per-group merge policy.

- **Policy**: comma-separated `<group>:<max-update-type>` pairs (`merge_policy` input). Default: `quarkus:patch, build-tooling:minor, jooq:patch, actions:minor, frontend-runtime-patch:patch, frontend-tooling:minor`. Majors and ungrouped PRs (internal artifacts) are never auto-merged.
- The defaults follow measured merge behavior across uniport repos (264 recent Dependabot PRs): Quarkus patches were merged 100% of the time, build tooling >80% up to minor, while test dependencies were deferred by a human in 13 of 14 cases and are deliberately not auto-mergeable.
- **Merges as the Uniport GitHub App** (not `GITHUB_TOKEN`), so the merge still triggers the regular main pipelines. Requires `Contents: write` + `Pull requests: write` on the calling repo.
- **Human override**: a human commit on a Dependabot branch changes the actor and permanently disarms auto-merge for that PR; `@dependabot rebase` hands it back to the bot. The merge is immediate (GitHub's native auto-merge is deliberately not armed), so a later green build never merges a human-touched PR.

## Usage (from a repo's dependabot-pr.yml)

```yaml
  automerge:
    name: Auto-Merge
    needs: build
    if: ${{ github.actor == 'dependabot[bot]' }}
    permissions:
      contents: read
      pull-requests: read
    uses: uniport/workflows/.github/workflows/shared-dependabot-automerge.yml@main
    secrets:
      UNIPORT_APP_PRIVATE_KEY: ${{ secrets.UNIPORT_APP_PRIVATE_KEY }}
```

## Rollout

Pilot in `uniport/conversation` (PR follows); other service repos after the pilot proves out. This PR must merge first since callers reference `@main`.