### PR TITLE
perf(ci): disable Aether remote-origin re-verification of cached arti…

### DIFF
--- a/.github/workflows/main-maven-build.yml
+++ b/.github/workflows/main-maven-build.yml
@@ -132,9 +132,10 @@ jobs:
         run: |
           cp -Rpf ~/.docker ${{ env.DOCKER_CONFIG_DIRECTORY }}
 
+      # No Aether origin re-verification per artifact (see shared-maven-build.yml)
       - name: Build & deploy with Maven
         run: |
-          mvn -B -V --no-transfer-progress --update-snapshots --settings .github/settings.xml -DmultiArchBuild=true deploy -Ddocker.dockerStateDir=${{ env.DOCKER_CONFIG_DIRECTORY }}
+          mvn -B -V --no-transfer-progress --update-snapshots --settings .github/settings.xml -Daether.enhancedLocalRepository.trackingFilename=_NOT_USED_ -DmultiArchBuild=true deploy -Ddocker.dockerStateDir=${{ env.DOCKER_CONFIG_DIRECTORY }}
         env:
           PACKAGE_VERSION: ${{ steps.vars.outputs.RC_VERSION }}
 

--- a/.github/workflows/shared-maven-build.yml
+++ b/.github/workflows/shared-maven-build.yml
@@ -164,9 +164,13 @@ jobs:
         run: |
           find ~/.m2/repository -name "maven-metadata-local.xml" -delete 2>/dev/null || true
 
+      # Disabling the Aether tracking file (_remote.repositories) skips the per-artifact
+      # re-verification of which remote a cached artifact came from on the persistent
+      # macduff ~/.m2 caches; all repositories resolve through the same Nexus group mirror
+      # anyway (settings.xml has mirrorOf=*).
       - name: Execute Maven Deploy (Build, Test, and Push)
         run: |
-          mvn -B -V --no-transfer-progress --update-snapshots --settings .github/settings.xml ${{ inputs.maven_verbose && '-e -X' || '' }} -DmultiArchBuild=true deploy -Ddocker.dockerStateDir=${{ env.DOCKER_CONFIG_DIRECTORY }}
+          mvn -B -V --no-transfer-progress --update-snapshots --settings .github/settings.xml ${{ inputs.maven_verbose && '-e -X' || '' }} -Daether.enhancedLocalRepository.trackingFilename=_NOT_USED_ -DmultiArchBuild=true deploy -Ddocker.dockerStateDir=${{ env.DOCKER_CONFIG_DIRECTORY }}
         env:
           PACKAGE_VERSION: ${{ steps.vars.outputs.RC_VERSION }}
 

--- a/.github/workflows/test-maven.yml
+++ b/.github/workflows/test-maven.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Maven build
         run: |
-          mvn -B -V --no-transfer-progress --update-snapshots -P!local,ci -DmultiArchBuild=true verify
+          mvn -B -V --no-transfer-progress --update-snapshots -Daether.enhancedLocalRepository.trackingFilename=_NOT_USED_ -P!local,ci -DmultiArchBuild=true verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `shared-dependabot-automerge.yml`: approves and rebase-merges Dependabot PRs after the calling repository's build passed, based on a per-group merge policy (`merge_policy` input; majors, test dependencies and ungrouped/internal dependencies always stay human-reviewed). Merges as the Uniport GitHub App so the regular pipelines on the default branch still trigger; any human commit on a Dependabot branch disarms auto-merge ([GH-51](https://github.com/uniport/workflows/pull/51))
 - `shared-build-pipeline.yml` now generates a CycloneDX SBOM (npm frontend sources + syft scan of every pushed Docker image), attests SBOM and SLSA provenance to each image via cosign (key-based, public key published as `cosign.pub`), and uploads the SBOM to Dependency-Track. Runs on the default branch and `X.Y.x` maintenance branches (`sbom_ref_pattern` input, opt out via `generate_sbom: false`); attestation and upload are skipped with a notice when the new optional secrets (`COSIGN_PRIVATE_KEY`, `COSIGN_PASSWORD`, `DEPENDENCY_TRACK_API_KEY`) are absent. New base actions: `nexus-list-docker-images`, `generate-sbom`, `upload-sbom-dependency-track` (see the README section "SBOM, Attestation & Dependency-Track")
 
+### Changed
+
+- The Maven build invocations in `shared-maven-build.yml`, `main-maven-build.yml` and `test-maven.yml` now disable Aether's remote-origin re-verification of cached artifacts (`-Daether.enhancedLocalRepository.trackingFilename=_NOT_USED_`), skipping a per-artifact check against Nexus on the persistent runner caches; all repositories resolve through the same Nexus group mirror, so the origin check bought nothing
+
 ### Fixed
 
 - `release-docker-images` now also copies cosign attestation and signature tags (`sha256-<digest>.att`/`.sig`) when promoting Docker images from staging to release, so released images stay verifiable after staging cleanup; image copies now run sequentially and properly fail the job on errors


### PR DESCRIPTION
…facts

With a persistent local repository, Maven's enhanced local repository manager records for every artifact which remote it came from (_remote.repositories) and re-verifies the origin on later builds, causing per-artifact overhead even when everything is cached. All repositories resolve through the same Nexus group mirror (settings.xml has mirrorOf=*), so this check buys nothing on the macduff runners.

--update-snapshots stays DELIBERATELY (evaluated on Maven 3.9.9): a failed artifact download (e.g. a just-released version Nexus didn't serve yet) is recorded as not-found in the persistent ~/.m2 and not retried for up to a day per the release update policy - poisoning later builds on the same runner that resolve the same released version (api jars, dependabot bumps, archetype builds). -U forces the re-check on every build and is cheap: internal artifacts are immutable releases, so it re-downloads nothing that is cached.