### PR TITLE
Generate the npm SBOM whenever sbom_npm_path exists

### DIFF
--- a/.github/actions/base/generate-sbom/action.yml
+++ b/.github/actions/base/generate-sbom/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: Nexus repository ID of the Docker staging repository to search for images
     required: true
   npm-path:
-    description: Path to the npm project directory to include in the SBOM (empty = no npm SBOM)
+    description: Path to the npm project directory to include in the SBOM (empty or non-existent = no npm SBOM)
     required: false
     default: ''
   cosign-private-key:
@@ -83,6 +83,16 @@ runs:
         NPM_PATH: ${{ inputs.npm-path }}
         VERSION: ${{ inputs.version }}
       run: |
+        # Callers forward the path unconditionally, so a missing one means "no npm project here".
+        if [ ! -d "$NPM_PATH" ]; then
+          echo "::notice::No npm project at '${NPM_PATH}', skipping the npm SBOM."
+          exit 0
+        fi
+        if [ ! -f "${NPM_PATH}/package.json" ]; then
+          echo "::warning::'${NPM_PATH}' has no package.json, skipping the npm SBOM."
+          exit 0
+        fi
+
         "$SYFT" scan "dir:${NPM_PATH}" \
           --source-name "${GITHUB_REPOSITORY#*/}-npm" --source-version "$VERSION" \
           -o cyclonedx-json@1.6=sbom-npm.cyclonedx.json

--- a/.github/workflows/shared-build-pipeline.yml
+++ b/.github/workflows/shared-build-pipeline.yml
@@ -84,7 +84,7 @@ on:
         type: boolean
         default: true
       sbom_npm_path:
-        description: 'Path to the npm project included in the SBOM (only used when has_frontend is true)'
+        description: 'Path to the npm project included in the SBOM. Skipped when the path does not exist; set to an empty string to opt out.'
         required: false
         type: string
         default: 'frontend/src/main/web'
@@ -201,7 +201,7 @@ jobs:
     uses: ./.github/workflows/shared-sbom.yml
     with:
       version: ${{ needs.maven.outputs.VERSION }}
-      npm_path: ${{ inputs.has_frontend && inputs.sbom_npm_path || '' }}
+      npm_path: ${{ inputs.sbom_npm_path }}
       sbom_ref_pattern: ${{ inputs.sbom_ref_pattern }}
     secrets:
       NEXUS3_PW: ${{ secrets.NEXUS3_PW }}

--- a/.github/workflows/shared-sbom.yml
+++ b/.github/workflows/shared-sbom.yml
@@ -29,7 +29,7 @@ on:
         required: true
         type: string
       npm_path:
-        description: 'Path to an npm project to include in the SBOM (empty = no npm SBOM)'
+        description: 'Path to an npm project to include in the SBOM (empty or non-existent = no npm SBOM)'
         required: false
         type: string
         default: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `generate-sbom` now scans the built Docker images with syft concurrently (4 at a time) instead of sequentially. The scans are network-bound at roughly 30 seconds per image, so on multi-image builds this cuts several minutes off the SBOM job, which sits on the critical path of the shared pipeline (measured on `notification` with 12 images: scan block down from ~6 minutes). Per-scan output is written to log files and emitted as collapsible log groups, and a failing scan still fails the step and names the affected image
+- The npm part of the SBOM is now generated whenever `sbom_npm_path` (default `frontend/src/main/web`) exists, and skipped with a notice when it does not. `conversation`, `dashboard` and `notification` gain their npm dependency tree in the SBOM; repositories without an npm project need no configuration. Set `sbom_npm_path: ''` to opt out
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A collection of reusable workflows and composite actions to avoid duplicating th
 
 The [shared build pipeline](./.github/workflows/shared-build-pipeline.yml) generates a CycloneDX SBOM for every build of the default branch and of `X.Y.x` maintenance branches (configurable via the `sbom_ref_pattern` input, opt out with `generate_sbom: false`):
 
-- **SBOM**: npm frontend sources (production dependencies) plus a syft scan of every Docker image the build pushed, merged into a single `sbom.cyclonedx.json` run artifact.
+- **SBOM**: npm frontend sources (production dependencies) plus a syft scan of every Docker image the build pushed, merged into a single `sbom.cyclonedx.json` run artifact. The npm project comes from `sbom_npm_path` (default `frontend/src/main/web`), skipped when that path does not exist. Point it elsewhere for a frontend outside the default path, or set it to an empty string to opt out.
 - **Attestation**: the SBOM and a SLSA provenance predicate are attached to each image (by digest) with [cosign](https://github.com/sigstore/cosign), signed with the Uniport key pair. The public key is [cosign.pub](./cosign.pub). Verify with:
 
   ```sh


### PR DESCRIPTION
shared-build-pipeline.yml forwards sbom_npm_path to the SBOM job unconditionally, and generate-sbom skips a non-existent path with a notice. conversation, dashboard and notification gain their npm dependency tree; repos without an npm project need no configuration.