### PR TITLE
Let Dependabot see the pins in our composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
     #    allow:
     #      - dependency-type: "production"
     open-pull-requests-limit: 10
+  # `directory: '/'` covers only `.github/workflows/` and a root `action.yml`, never composite
+  # actions (https://github.com/dependabot/dependabot-core/issues/6345). The globs add both
+  # nesting levels in use here.
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - '/'
+      - '/.github/actions/*'
+      - '/.github/actions/*/*'
     schedule:
       interval: 'weekly'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `copy-docker-images` now also copies the cosign attestation and signature tags (`sha256-<digest>.att`/`.sig`) alongside the image, so images mirrored to another registry (e.g. the public GitHub Container Registry) stay verifiable with `cosign verify-attestation`
 - `shared-maven-build.yml` now checks out the PR head under `pull_request_target` so Dependabot PR builds verify the proposed changes instead of the base branch
 - `publish-spotbugs-report` and `publish-checkstyle-report` now publish the report before failing on violations, and no longer add a confusing secondary failure when the analysis cannot run because an earlier build step failed (e.g. unresolvable dependencies) ([GH-50](https://github.com/uniport/workflows/pull/50))
+- Dependabot now also checks the actions pinned in our composite actions under `.github/actions/`, which `directory: '/'` never covered ([dependabot-core#6345](https://github.com/dependabot/dependabot-core/issues/6345))
 
 [unreleased]: https://github.com/uniport/workflows/compare/73134d30c856eaabc9c891492f265b896517382c...main


### PR DESCRIPTION
## Why

For the `github-actions` ecosystem, `directory: '/'` fetches only `.github/workflows/*.y*ml` plus an `action.yml` in the repository root. Everything under `.github/actions/` is therefore never checked, so the third-party actions our composite actions depend on go stale silently. Two of them had been sitting on a release from August 2024.

Source: `github_actions/file_fetcher.rb` in dependabot-core (for a non-root directory it fetches YAML files in that directory only, no recursion). Upstream issue, still open: https://github.com/dependabot/dependabot-core/issues/6345.

Confirmed for this repository: no Dependabot commit on `main` has ever touched a file under `.github/actions/`.

## What

`directories` with `/`, `/.github/actions/*` and `/.github/actions/*/*`, the two nesting levels in use here (`.github/actions/<name>/` and `.github/actions/base/<name>/`). Only `*` is used, which is the documented wildcard. Matched directories that hold no manifest are skipped, so a new composite action needs no further config.

The pattern is proven in the wild: `keycloak/keycloak` and `aquasecurity/trivy` use `/.github/actions/*`, `neovim/neovim` and `openvinotoolkit/openvino` use `/.github/actions/**/*`, and all four have real Dependabot commits under that tree.

## What to expect

A one-off batch of Dependabot PRs for the pins that were hidden until now, including the Checkstyle and SpotBugs report actions. This repository does not call `shared-dependabot-automerge`, so all of them wait for a human. If no PRs appear after the next scheduled run, the globs did not match and this needs a second look.

## Scope

Only this repository is affected in practice. Of the 58 non-archived repositories in the org, only `uniport/workflows`, `uniport/build-status` and `uniport/uniport-authz` have an `action.y*ml` outside `.github/workflows/` at all, and `uniport-authz` has no third-party `uses:` in its one file. `build-status` has the same gap and is worth a separate PR.

Follows on from the `notification` build pipeline analysis, where the stale pins showed up as a Node 20 deprecation warning in the job log. Note that the pending v3.2.0 releases of the two lcollins actions do not resolve that warning: they still declare `node20`.
