### PR TITLE
chore(deps): pin Dependabot schedule to Monday 23:00

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '23:00'
+      timezone: 'Europe/Zurich'
     #    allow:
     #      - dependency-type: "production"
     open-pull-requests-limit: 10
@@ -32,6 +35,9 @@ updates:
       - '/.github/actions/*/*'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '23:00'
+      timezone: 'Europe/Zurich'
     cooldown:
       default-days: 30
     groups:


### PR DESCRIPTION
GitHub had assigned this repo an unpinned weekly slot, most recently Monday 17:00, inside working hours where Dependabot PR checks compete with developer builds on the shared self-hosted runners.

Pins it to Monday 23:00 Europe/Zurich, a window no other repo in the org uses.

Part of a sweep across the org: all 78 update entries were a bare `interval: weekly`, so GitHub chose every slot, which left Monday carrying half the fleet and peaked at 70 PRs in one day.
