### PR TITLE
fix(ci): run Dependabot auto-merge on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/shared-dependabot-automerge.yml
+++ b/.github/workflows/shared-dependabot-automerge.yml
@@ -54,7 +54,7 @@ on:
 jobs:
   automerge:
     name: Auto-Merge
-    runs-on: macduff
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }} # Ensure this only runs for bot-initiated PRs
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
The job only calls the GitHub API, and the self-hosted 'macduff' runner group is not available to public repositories, so the Auto-Merge check on uniport-gateway queued indefinitely.